### PR TITLE
Introduce ploop-volume cli

### DIFF
--- a/ploop_exec.go
+++ b/ploop_exec.go
@@ -65,3 +65,38 @@ func ploopOut(args ...string) (string, error) {
 	}
 	return out, ret
 }
+
+func ploopVolumeRunCmd(stdout io.Writer, args ...string) error {
+	var stderr bytes.Buffer
+	cmd := exec.Command("ploop-volume", args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err == nil {
+		return nil
+	}
+
+	// Command returned an error, get the stderr
+	errStr := stderr.String()
+	// Get the exit code (Unix-specific)
+	if exiterr, ok := err.(*exec.ExitError); ok {
+		if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+			errCode := status.ExitStatus()
+			return &Err{c: errCode, s: errStr}
+		}
+	}
+	// unknown exit code
+	return &Err{c: -1, s: errStr}
+}
+
+func ploopVolume(args ...string) error {
+	return ploopVolumeRunCmd(nil, args...)
+}
+
+func ploopVolumeOut(args ...string) (string, error) {
+	var stdout bytes.Buffer
+	ret := ploopVolumeRunCmd(&stdout, args...)
+	out := stdout.String()
+	return out, ret
+}

--- a/ploop_volume.go
+++ b/ploop_volume.go
@@ -1,0 +1,97 @@
+package ploop
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+)
+
+var (
+	ploopVolumeBinary = "/usr/sbin/ploop-volume"
+)
+
+type PloopVolume struct {
+	Path string
+}
+
+type PloopVolumeSnapshot struct {
+	Path string
+}
+
+func checkDD(src string) error {
+	if _, err := os.Stat(path.Join(src, "DiskDescriptor.xml")); os.IsNotExist(err) {
+		return &Err{c: -1, s: fmt.Sprintf("Bad ploop-volume path %s!", src)}
+	}
+	return nil
+}
+
+func PloopVolumeOpen(src string) (*PloopVolume, error) {
+	if err := checkDD(src); err != nil {
+		return nil, err
+	}
+	return &PloopVolume{src}, nil
+}
+
+func PloopVolumeSnapshotOpen(src string) (*PloopVolumeSnapshot, error) {
+	if err := checkDD(src); err != nil {
+		return nil, err
+	}
+	return &PloopVolumeSnapshot{src}, nil
+}
+
+func PloopVolumeCreate(src string, size uint64, image string) (*PloopVolume, error) {
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		return nil, &Err{c: -1, s: fmt.Sprintf("Destination ploop directory already exists %s!", src)}
+	}
+
+	args := []string{"create", "-s", strconv.FormatUint(size, 10) + "K"}
+	if image != "" {
+		args = append(args, "--image", image)
+	}
+	args = append(args, src)
+	if err := ploopVolume(args...); err != nil {
+		return nil, err
+	}
+	return &PloopVolume{src}, nil
+}
+
+func (pv *PloopVolume) Snapshot(dst string) (*PloopVolumeSnapshot, error) {
+	if dst == "" {
+		return nil, &Err{c: -1, s: fmt.Sprintf("Bad destination path!")}
+	}
+	err := ploopVolume("snapshot", pv.Path, dst)
+	if err != nil {
+		return nil, err
+	}
+	return &PloopVolumeSnapshot{dst}, nil
+}
+
+func (pvs *PloopVolumeSnapshot) Switch(pv PloopVolume) error {
+	if err := checkDD(pv.Path); err != nil {
+		return err
+	}
+	if err := checkDD(pvs.Path); err != nil {
+		return err
+	}
+	return ploopVolume("switch", pvs.Path, pv.Path)
+}
+
+func (pvs *PloopVolumeSnapshot) Clone(dst string) (*PloopVolume, error) {
+	if err := checkDD(pvs.Path); err != nil {
+		return nil, err
+	}
+	err := ploopVolume("clone", pvs.Path, dst)
+	if err != nil {
+		return nil, err
+	}
+	return &PloopVolume{dst}, nil
+}
+
+func (pv *PloopVolume) Delete() error {
+	return ploopVolume("delete", pv.Path)
+}
+
+func (pvs *PloopVolumeSnapshot) Delete() error {
+	return ploopVolume("delete", pvs.Path)
+}


### PR DESCRIPTION
ploop-volume should help storing snapshots without it parent. original
ploop supports only strict hierarchy which cannot exist without parent.
However, k8s provides no warranty for parent to be. ploop-volume clone
operation fully restores ploop from its snapshot without parent
Signed-off-by: Alexander Burluka <aburluka@virtuozzo.com>