### PR TITLE
Allow to create a ploop volume in a pre-created directory

### DIFF
--- a/ploop_volume.go
+++ b/ploop_volume.go
@@ -41,10 +41,6 @@ func PloopVolumeSnapshotOpen(src string) (*PloopVolumeSnapshot, error) {
 }
 
 func PloopVolumeCreate(src string, size uint64, image string) (*PloopVolume, error) {
-	if _, err := os.Stat(src); !os.IsNotExist(err) {
-		return nil, &Err{c: -1, s: fmt.Sprintf("Destination ploop directory already exists %s!", src)}
-	}
-
 	args := []string{"create", "-s", strconv.FormatUint(size, 10) + "K"}
 	if image != "" {
 		args = append(args, "--image", image)

--- a/ploop_volume.go
+++ b/ploop_volume.go
@@ -7,10 +7,6 @@ import (
 	"strconv"
 )
 
-var (
-	ploopVolumeBinary = "/usr/sbin/ploop-volume"
-)
-
 type PloopVolume struct {
 	Path string
 }


### PR DESCRIPTION
Some vstorage attributes (e.g. encoding parameters) has to be set on a
directory, and they are applied only for new files.

So if a user wants to set encoding parameters, he has to create a
directory, set vstorage attributes on it and only then he can create a
ploop volume.

Signed-off-by: Andrei Vagin <avagin@openvz.org>